### PR TITLE
Allow plugins to modify outgoing group invitation notifications

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -67,6 +67,14 @@
 				// notify user
 				$subject = elgg_echo("group_tools:groups:invite:add:subject", array($group->name));
 				$msg = elgg_echo("group_tools:groups:invite:add:body", array($user->name, $loggedin_user->name, $group->name, $text, $group->getURL()));
+				
+				$params = array(
+					'group' => $group,
+					'inviter' => $loggedin_user,
+					'invitee' => $user
+				);
+				$msg = elgg_trigger_plugin_hook('invite_notification', 'group_tools', $params, $msg);
+
 					
 				if(notify_user($user->getGUID(), $group->getOwnerGUID(), $subject, $msg, null, "email")){
 					$result = true;
@@ -124,6 +132,13 @@
 					elgg_get_site_url() . "groups/invitations/?invitecode=" . $invite_code,
 					$invite_code)
 				);
+				
+				$params = array(
+					'group' => $group,
+					'inviter' => $loggedin_user,
+					'invitee' => $email
+				);
+				$body = elgg_trigger_plugin_hook('invite_notification', 'group_tools', $params, $body);
 				
 				$result = elgg_send_email($site_from, $email, $subject, $body);
 			} else {


### PR DESCRIPTION
This just adds a couple of plugin hooks just before the notification is sent to allow others (me) to modify the message on the fly.  I need this because we're wanting to tag any outgoing links/urls with additional parameters for analytics, and currently there's no way to target these notifications with this plugin active without creating a fork.
