### PR TITLE
Using output/url instead of output/confirmlink (deprecated)

### DIFF
--- a/views/default/admin/administer_utilities/group_bulk_delete.php
+++ b/views/default/admin/administer_utilities/group_bulk_delete.php
@@ -71,7 +71,7 @@ foreach ($batch as $group) {
 		"text" => elgg_view_icon("settings-alt"),
 		"title" => elgg_echo("edit"),
 		"href" => "groups/edit/" . $group->getGUID())) . "</td>";
-	$form_data .= "<td class='center'>" . elgg_view("output/confirmlink", array(
+	$form_data .= "<td class='center'>" . elgg_view("output/url", array(
 		"text" => elgg_view_icon("delete-alt"),
 		"title" => elgg_echo("delete"),
 		"confirm" => elgg_echo("deleteconfirm"),

--- a/views/default/forms/groups/edit.php
+++ b/views/default/forms/groups/edit.php
@@ -42,7 +42,7 @@ echo elgg_view("input/submit", array("value" => elgg_echo("save")));
 
 if ($entity) {
 	$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
-	echo elgg_view("output/confirmlink", array(
+	echo elgg_view("output/url", array(
 		"text" => elgg_echo("groups:delete"),
 		"href" => $delete_url,
 		"confirm" => elgg_echo("groups:deletewarning"),

--- a/views/default/group_tools/forms/notifications.php
+++ b/views/default/group_tools/forms/notifications.php
@@ -41,19 +41,21 @@ if (!empty($user) && $user->isAdmin()) {
 		
 		// enable notification for everyone
 		if ($member_count > $notification_count) {
-			$content .= elgg_view("output/confirmlink", array(
+			$content .= elgg_view("output/url", array(
 				"href" => "action/group_tools/notifications?toggle=enable&guid=" . $group->getGUID(),
 				"text" => elgg_echo("group_tools:notifications:enable"),
-				"class" => "elgg-button elgg-button-submit mrm"
+				"class" => "elgg-button elgg-button-submit mrm",
+				"confirm" => true
 			));
 		}
 		
 		// disable notification
 		if ($notification_count > 0) {
-			$content .= elgg_view("output/confirmlink", array(
+			$content .= elgg_view("output/url", array(
 				"href" => "action/group_tools/notifications?toggle=disable&guid=" . $group->getGUID(),
 				"text" => elgg_echo("group_tools:notifications:disable"),
-				"class" => "elgg-button elgg-button-submit"
+				"class" => "elgg-button elgg-button-submit",
+				"confirm" => true
 			));
 		}
 		

--- a/views/default/group_tools/membershipreq/email_invites.php
+++ b/views/default/group_tools/membershipreq/email_invites.php
@@ -13,7 +13,7 @@ if (!empty($emails)) {
 		$email_title = elgg_view("output/email", array("value" => $email));
 
 		$url = "action/group_tools/revoke_email_invitation?annotation_id=" . $annotation->id . "&group_guid=" . $group->getGUID();
-		$delete_button = elgg_view("output/confirmlink", array(
+		$delete_button = elgg_view("output/url", array(
 			"href" => $url,
 			"confirm" => elgg_echo("group_tools:groups:membershipreq:invitations:revoke:confirm"),
 			"text" => elgg_echo("group_tools:revoke"),

--- a/views/default/group_tools/membershipreq/invites.php
+++ b/views/default/group_tools/membershipreq/invites.php
@@ -17,7 +17,7 @@ if (!empty($invitations) && is_array($invitations)) {
 		));
 
 		$url = "action/groups/killinvitation?user_guid=" . $user->getGUID() . "&group_guid=" . $group->getGUID();
-		$delete_button = elgg_view("output/confirmlink", array(
+		$delete_button = elgg_view("output/url", array(
 			"href" => $url,
 			"confirm" => elgg_echo("group_tools:groups:membershipreq:invitations:revoke:confirm"),
 			"text" => elgg_echo("group_tools:revoke"),

--- a/views/default/groups/invitationrequests.php
+++ b/views/default/groups/invitationrequests.php
@@ -35,7 +35,7 @@ if ((!empty($invitations) && is_array($invitations)) || (!empty($email_invites) 
 				));
 	
 				$url = "action/groups/killinvitation?user_guid=" . $user->getGUID() . "&group_guid=" . $group->getGUID();
-				$delete_button = elgg_view("output/confirmlink", array(
+				$delete_button = elgg_view("output/url", array(
 					"href" => $url,
 					"confirm" => elgg_echo("groups:invite:remove:check"),
 					"text" => elgg_echo("delete"),
@@ -75,7 +75,7 @@ if ((!empty($invitations) && is_array($invitations)) || (!empty($email_invites) 
 			));
 			
 			$url = "action/groups/decline_email_invitation?invitecode=" . group_tools_generate_email_invite_code($group->getGUID(), $user->email);
-			$delete_button = elgg_view("output/confirmlink", array(
+			$delete_button = elgg_view("output/url", array(
 				"href" => $url,
 				"confirm" => elgg_echo("groups:invite:remove:check"),
 				"text" => elgg_echo("delete"),
@@ -118,7 +118,7 @@ if (elgg_get_context() == "groups") {
 			));
 			
 			$url = "action/groups/killrequest?user_guid=" . $user->getGUID() . "&group_guid=" . $group->getGUID();
-			$delete_button = elgg_view("output/confirmlink", array(
+			$delete_button = elgg_view("output/url", array(
 				"href" => $url,
 				"confirm" => elgg_echo("group_tools:group:invitations:request:revoke:confirm"),
 				"text" => elgg_echo("group_tools:revoke"),

--- a/views/default/groups/membershiprequests.php
+++ b/views/default/groups/membershiprequests.php
@@ -32,7 +32,7 @@ if (!empty($requests) && is_array($requests)) {
 		));
 
 		$url = "action/groups/killrequest?user_guid=" . $user->getGUID() . "&group_guid=" . $group->getGUID();
-		$delete_button = elgg_view("output/confirmlink", array(
+		$delete_button = elgg_view("output/url", array(
 			"href" => $url,
 			"confirm" => elgg_echo("groups:joinrequest:remove:check"),
 			"text" => elgg_echo("delete"),

--- a/views/default/plugins/group_tools/settings.php
+++ b/views/default/plugins/group_tools/settings.php
@@ -237,10 +237,11 @@ if ($featured_groups = elgg_get_entities_from_metadata($options)) {
 		$content .= "<tr>";
 		$content .= "<td>" . elgg_view("output/url", array("href" => $group->getURL(), "text" => $group->name)) . "</td>";
 		$content .= "<td style='width: 25px'>";
-		$content .= elgg_view("output/confirmlink", array(
+		$content .= elgg_view("output/url", array(
 			"href" => "action/groups/featured?group_guid=" . $group->getGUID(),
 			"title" => elgg_echo("group_tools:remove"),
 			"text" => elgg_view_icon("delete"),
+			"confirm" => true
 		));
 		$content .= "</td>";
 		$content .= "</tr>";
@@ -286,10 +287,11 @@ if (!empty($auto_joins)) {
 			$content .= "<tr>";
 			$content .= "<td>" . elgg_view("output/url", array("href" => $group->getURL(), "text" => $group->name)) . "</td>";
 			$content .= "<td style='width: 25px'>";
-			$content .= elgg_view("output/confirmlink", array(
+			$content .= elgg_view("output/url", array(
 				"href" => "action/group_tools/toggle_special_state?group_guid=" . $group->getGUID() . "&state=auto_join",
 				"title" => elgg_echo("group_tools:remove"),
 				"text" => elgg_view_icon("delete"),
+				"confirm" => true
 			));
 			$content .= "</td>";
 			$content .= "</tr>";
@@ -337,10 +339,11 @@ if (!empty($suggested_groups)) {
 			$content .= "<tr>";
 			$content .= "<td>" . elgg_view("output/url", array("href" => $group->getURL(), "text" => $group->name)) . "</td>";
 			$content .= "<td style='width: 25px'>";
-			$content .= elgg_view("output/confirmlink", array(
+			$content .= elgg_view("output/url", array(
 				"href" => "action/group_tools/toggle_special_state?group_guid=" . $group->getGUID() . "&state=suggested",
 				"title" => elgg_echo("group_tools:remove"),
 				"text" => elgg_view_icon("delete"),
+				"confirm" => true
 			));
 			$content .= "</td>";
 			$content .= "</tr>";
@@ -368,12 +371,13 @@ $rows = array();
 if ($missing_acl_members = group_tools_get_missing_acl_users()) {
 	$rows[] = array(
 		elgg_echo("group_tools:settings:fix:missing", array(count($missing_acl_members))),
-		elgg_view("output/confirmlink", array(
+		elgg_view("output/url", array(
 			"href" => "action/group_tools/fix_acl?fix=missing",
 			"text" => elgg_echo("group_tools:settings:fix_it"),
 			"class" => "elgg-button elgg-button-action",
 			"is_action" => true,
-			"style" => "white-space: nowrap;"
+			"style" => "white-space: nowrap;",
+			"confirm" => true
 		))
 	);
 }
@@ -382,12 +386,13 @@ if ($missing_acl_members = group_tools_get_missing_acl_users()) {
 if ($excess_acl_members = group_tools_get_excess_acl_users()) {
 	$rows[] = array(
 		elgg_echo("group_tools:settings:fix:excess", array(count($excess_acl_members))),
-		elgg_view("output/confirmlink", array(
+		elgg_view("output/url", array(
 			"href" => "action/group_tools/fix_acl?fix=excess",
 			"text" => elgg_echo("group_tools:settings:fix_it"),
 			"class" => "elgg-button elgg-button-action",
 			"is_action" => true,
-			"style" => "white-space: nowrap;"
+			"style" => "white-space: nowrap;",
+			"confirm" => true
 		))
 	);
 }
@@ -396,12 +401,13 @@ if ($excess_acl_members = group_tools_get_excess_acl_users()) {
 if ($wrong_groups = group_tools_get_groups_without_acl()) {
 	$rows[] = array(
 		elgg_echo("group_tools:settings:fix:without", array(count($wrong_groups))),
-		elgg_view("output/confirmlink", array(
+		elgg_view("output/url", array(
 			"href" => "action/group_tools/fix_acl?fix=without",
 			"text" => elgg_echo("group_tools:settings:fix_it"),
 			"class" => "elgg-button elgg-button-action",
 			"is_action" => true,
-			"style" => "white-space: nowrap;"
+			"style" => "white-space: nowrap;",
+			"confirm" => true
 		))
 	);
 }
@@ -410,12 +416,13 @@ if ($wrong_groups = group_tools_get_groups_without_acl()) {
 if (count($rows) > 1) {
 	$rows[] = array(
 		elgg_echo("group_tools:settings:fix:all:description"),
-		elgg_view("output/confirmlink", array(
+		elgg_view("output/url", array(
 			"href" => "action/group_tools/fix_acl?fix=all",
 			"text" => elgg_echo("group_tools:settings:fix:all"),
 			"class" => "elgg-button elgg-button-action",
 			"is_action" => true,
-			"style" => "white-space: nowrap;"
+			"style" => "white-space: nowrap;",
+			"confirm" => true
 		))
 	);
 }


### PR DESCRIPTION
I've gone through and replaced all usage of output/confirmlink with output/url and added the "confirm" parameter where necessary. 