### PR TITLE
decode quotes in group names for email subject

### DIFF
--- a/lib/events.php
+++ b/lib/events.php
@@ -77,7 +77,8 @@ function group_tools_join_group_event($event, $type, $params) {
 				$welcome_message = str_ireplace("[group_url]", $group->getURL(), $welcome_message);
 				
 				// notify the user
-				notify_user($user->getGUID(), $group->getGUID(), elgg_echo("group_tools:welcome_message:subject", array($group->name)), $welcome_message);
+				$group_name = html_entity_decode($group->name, ENT_QUOTES);
+				notify_user($user->getGUID(), $group->getGUID(), elgg_echo("group_tools:welcome_message:subject", array($group_name)), $welcome_message);
 			}
 		}
 	}


### PR DESCRIPTION
Group names are html encoded, so using the name directly in an email subject will show the encoded quotes.

eg.
```Welcome to Group&#039;s welcome test```

So lets decode them before using them in an email subject