### PR TITLE
fix: make sure discussions plugin is enabled

### DIFF
--- a/start.php
+++ b/start.php
@@ -73,8 +73,9 @@ function group_tools_init() {
 	elgg_register_widget_type("index_groups", elgg_echo("groups"), elgg_echo("widgets:index_groups:description"), array("index"), true);
 	
 	// quick start discussion
-	elgg_register_widget_type("start_discussion", elgg_echo("group_tools:widgets:start_discussion:title"), elgg_echo("group_tools:widgets:start_discussion:description"), array("index", "dashboard", "groups"));
-	
+	if (elgg_is_active_plugin('discussions')) {
+		elgg_register_widget_type("start_discussion", elgg_echo("group_tools:widgets:start_discussion:title"), elgg_echo("group_tools:widgets:start_discussion:description"), array("index", "dashboard", "groups"));
+	}
 	// group invitation
 	elgg_register_action("groups/invite", dirname(__FILE__) . "/actions/groups/invite.php");
 	
@@ -126,9 +127,10 @@ function group_tools_init() {
 	elgg_extend_view("theme_sandbox/forms", "group_tools/theme_sandbox/grouppicker");
 	
 	// register index widget to show latest discussions
-	elgg_register_widget_type("discussion", elgg_echo("discussion:latest"), elgg_echo("widgets:discussion:description"), array("index", "dashboard"), true);
-	elgg_register_widget_type("group_forum_topics", elgg_echo("discussion:group"), elgg_echo("widgets:group_forum_topics:description"), array("groups"));
-	
+	if (elgg_is_active_plugin('discussions')) {
+		elgg_register_widget_type("discussion", elgg_echo("discussion:latest"), elgg_echo("widgets:discussion:description"), array("index", "dashboard"), true);
+		elgg_register_widget_type("group_forum_topics", elgg_echo("discussion:group"), elgg_echo("widgets:group_forum_topics:description"), array("groups"));
+	}
 	// register events
 	elgg_register_event_handler("join", "group", "group_tools_join_group_event");
 	elgg_register_event_handler("delete", "relationship", array('ColdTrick\GroupTools\Membership', 'deleteRequest'));

--- a/views/default/groups/group_sort_menu.php
+++ b/views/default/groups/group_sort_menu.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * All groups listing page navigation
  *
  */
-
 $tabs = array(
 	"newest" => array(
 		"text" => elgg_echo("sort:newest"),
@@ -19,11 +19,6 @@ $tabs = array(
 		"text" => elgg_echo("sort:popular"),
 		"href" => "groups/all?filter=popular",
 		"priority" => 300,
-	),
-	"discussion" => array(
-		"text" => elgg_echo("groups:latestdiscussion"),
-		"href" => "groups/all?filter=discussion",
-		"priority" => 400,
 	),
 	"open" => array(
 		"text" => elgg_echo("group_tools:groups:sorting:open"),
@@ -57,6 +52,14 @@ $tabs = array(
 	),
 );
 
+if (elgg_is_active_plugin('discussions')) {
+	$tabs["discussion"] = array(
+		"text" => elgg_echo("groups:latestdiscussion"),
+		"href" => "groups/all?filter=discussion",
+		"priority" => 400,
+	);
+}
+
 foreach ($tabs as $name => $tab) {
 	$show_tab = false;
 	$show_tab_setting = elgg_get_plugin_setting("group_listing_" . $name . "_available", "group_tools");
@@ -67,18 +70,18 @@ foreach ($tabs as $name => $tab) {
 	} elseif ($show_tab_setting !== "0") {
 		$show_tab = true;
 	}
-	
+
 	if ($show_tab && in_array($name, array("yours", "suggested")) && !elgg_is_logged_in()) {
 		$show_tab = false;
 	}
-	
+
 	if ($show_tab) {
 		$tab["name"] = $name;
-		
+
 		if ($vars["selected"] == $name) {
 			$tab["selected"] = true;
 		}
-	
+
 		elgg_register_menu_item("filter", $tab);
 	}
 }

--- a/views/default/plugins/group_tools/settings.php
+++ b/views/default/plugins/group_tools/settings.php
@@ -24,7 +24,7 @@ $noyes3_options = array(
 );
 
 $listing_options = array(
-	"discussion" => elgg_echo("groups:latestdiscussion"),
+	"discussion" => elgg_echo("discussion:latest"),
 	"yours" => elgg_echo("groups:yours"),
 	"newest" => elgg_echo("sort:newest"),
 	"popular" => elgg_echo("sort:popular"),
@@ -35,6 +35,9 @@ $listing_options = array(
 	"featured" => elgg_echo("group_tools:groups:sorting:featured"),
 	"suggested" => elgg_echo("group_tools:groups:sorting:suggested"),
 );
+if (!elgg_is_active_plugin('discussions')) {
+	unset($listing_options['discussion']);
+}
 
 $hidden_indicator_options = array(
 	"no" => elgg_echo("option:no"),


### PR DESCRIPTION
In Elgg 2.x, discussions is its own plugin. Need to make sure, it is
enabled before registering widgets and tabs