### PR TITLE
fix delete email invitation error

### DIFF
--- a/actions/groups/decline_email_invitation.php
+++ b/actions/groups/decline_email_invitation.php
@@ -11,14 +11,22 @@ if (empty($invitecode)) {
 
 $options = [
 	'annotation_name' => 'email_invitation',
-	'annotation_value' => $invitecode,
+	'wheres' => [
+		"(v.string = '{$invitecode}' OR v.string LIKE '{$invitecode}|%')",
+	],
 	'limit' => false,
 ];
+
+// ignore access in order to cleanup the invitation
+$ia = elgg_set_ignore_access(true);
 
 if (elgg_delete_annotations($options)) {
 	system_message(elgg_echo('groups:invitekilled'));
 } else {
 	register_error(elgg_echo('group_tools:action:groups:decline_email_invitation:error:delete'));
 }
+// restore access
+elgg_set_ignore_access($ia);
 
-forward(REFERER);
+//forward to groups invitations page to remove invitecode query string
+forward("groups/invitations");


### PR DESCRIPTION
since 'annotation_value' always contains the user's email address, not only just the invitecode, elgg_delete_annotations($options) will always return null. The email invitation will not be deleted and return an error 'An error occured while deleting the invitation'. 