### PR TITLE
fix(invites): support longer TLDs

### DIFF
--- a/views/default/resources/group_tools/groups/group_invite_autocomplete.php
+++ b/views/default/resources/group_tools/groups/group_invite_autocomplete.php
@@ -71,7 +71,7 @@ if ($relationship != 'email') {
 	$users_found = elgg_get_entities_from_relationship($query_options);
 } else {
 	// invite by email
-	$regexpr = '/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/';
+	$regexpr = '/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/';
 	if (preg_match($regexpr, $q)) {
 		// only start matching if $q is an emailaddress
 		


### PR DESCRIPTION
We can now have valid TLDs with more than 4 characters.
Eg. the email address matt@civ.works is valid, but the invite form doesn't recognize it as such and doesn't prompt the select list.
Updated the regex to support the spec maximum 63 characters